### PR TITLE
Add LaTeX paper template

### DIFF
--- a/paper/.gitignore
+++ b/paper/.gitignore
@@ -1,0 +1,25 @@
+# LaTeX build
+*.aux
+*.bbl
+*.bcf
+*.blg
+*.fdb_latexmk
+*.fls
+*.log
+*.out
+*.run.xml
+*.toc
+*.synctex.gz
+*.lof
+*.lot
+*.nav
+*.snm
+*.vrb
+
+# Figures you regenerate
+figures/*.png
+figures/*.pdf
+figures/*.svg
+
+# OS / editor
+.DS_Store

--- a/paper/Makefile
+++ b/paper/Makefile
@@ -1,0 +1,16 @@
+# Build with: make        (uses latexmk + biber)
+# Clean with: make clean
+TEX=main
+all: $(TEX).pdf
+
+$(TEX).pdf: $(TEX).tex tex/commands.tex tex/sections/*.tex references.bib
+	latexmk -pdf -interaction=nonstopmode -file-line-error -shell-escape $(TEX).tex
+
+biber:
+	biber $(TEX)
+
+clean:
+	latexmk -C
+	@rm -f $(TEX).bbl $(TEX).bcf
+
+.PHONY: all clean biber

--- a/paper/README.md
+++ b/paper/README.md
@@ -1,0 +1,10 @@
+# Paper build
+
+This directory contains the LaTeX source for the paper.
+
+## Quick start
+```bash
+cd tennis_ml/paper
+make         # builds main.pdf using latexmk + biber
+make clean   # removes build artifacts
+```

--- a/paper/latexmkrc
+++ b/paper/latexmkrc
@@ -1,0 +1,4 @@
+# Use biber for biblatex
+$pdf_mode = 1;
+$pdflatex = 'pdflatex -interaction=nonstopmode -file-line-error -shell-escape %O %S';
+$biber = 'biber %O %B';

--- a/paper/main.tex
+++ b/paper/main.tex
@@ -1,0 +1,52 @@
+\documentclass[11pt]{article}
+\usepackage[margin=1in]{geometry}
+\usepackage{microtype}
+\usepackage{amsmath,amssymb,amsthm}
+\usepackage{graphicx}
+\usepackage{booktabs}
+\usepackage{caption}
+\usepackage{subcaption}
+\usepackage{csquotes}
+\usepackage{siunitx}
+\usepackage[backend=biber,style=authoryear,maxcitenames=2,uniquelist=false]{biblatex}
+\usepackage[hidelinks]{hyperref}
+\usepackage[nameinlink,capitalize]{cleveref}
+
+\addbibresource{references.bib}
+\graphicspath{{figures/}}
+
+% keep tables/figures near text
+\setlength{\abovecaptionskip}{6pt}
+\setlength{\belowcaptionskip}{0pt}
+
+% Commands/macros
+\input{tex/commands}
+
+\title{Pricing Tennis More Accurately than Volatile Prediction Markets:\\
+Evidence from \xgboost{} (and \lstm{} Roadmap) vs. \polymarket{}}
+\author{Your Name}
+\date{\today}
+
+\begin{document}
+\maketitle
+
+\input{tex/sections/00_abstract}
+\input{tex/sections/01_introduction}
+\input{tex/sections/02_related_work}
+\input{tex/sections/03_data}
+\input{tex/sections/04_models}
+\input{tex/sections/05_pricing_calibration}
+\input{tex/sections/06_microstructure_volatility}
+\input{tex/sections/07_trading_strategy}
+\input{tex/sections/08_backtesting}
+\input{tex/sections/09_results}
+\input{tex/sections/10_robustness_risk}
+\input{tex/sections/11_discussion}
+\input{tex/sections/12_conclusion_future}
+
+\printbibliography
+
+\appendix
+\input{tex/sections/A1_reproducibility}
+\input{tex/sections/A2_appendix}
+\end{document}

--- a/paper/references.bib
+++ b/paper/references.bib
@@ -1,0 +1,25 @@
+@misc{sackmannPBP,
+  author       = {Jeff Sackmann},
+  title        = {Point-by-Point Tennis Data},
+  howpublished = {\url{https://github.com/JeffSackmann/tennis_pointbypoint}},
+  note         = {Accessed: insert date}
+}
+
+@misc{polymarketData,
+  author       = {{Polymarket}},
+  title        = {Market Data Documentation},
+  howpublished = {\url{https://docs.polymarket.com/}},
+  note         = {Accessed: insert date}
+}
+
+@article{kelly1956,
+  author  = {Kelly, J. L.},
+  title   = {A New Interpretation of Information Rate},
+  journal = {Bell System Technical Journal},
+  year    = {1956},
+  volume  = {35},
+  number  = {4},
+  pages   = {917--926}
+}
+
+% Add your arXiv/other sources here; replace placeholders in text with real keys.

--- a/paper/tex/commands.tex
+++ b/paper/tex/commands.tex
@@ -1,0 +1,24 @@
+% Math & notation helpers
+\newcommand{\xgboost}{\textsc{XGBoost}}
+\newcommand{\lstm}{\textsc{LSTM}}
+\newcommand{\polymarket}{\textsc{Polymarket}}
+\newcommand{\pmodel}{p_{\mathrm{model}}}
+\newcommand{\pmarket}{p_{\mathrm{mkt}}}
+\newcommand{\edge}{\Delta}
+\newcommand{\brier}{\mathcal{B}}
+\newcommand{\logloss}{\mathcal{L}}
+\newcommand{\kelly}{f^{\ast}}
+\newcommand{\E}{\mathbb{E}}
+\newcommand{\Var}{\mathrm{Var}}
+\newcommand{\ind}{\mathbb{I}}
+\newcommand{\given}{\,|\,}
+\newcommand{\R}{\mathbb{R}}
+
+% Cleverref names
+\crefname{figure}{Fig.}{Figs.}
+\crefname{table}{Table}{Tables}
+\crefname{section}{Section}{Sections}
+
+% Table formatting
+\newcommand{\tblsm}{\small}
+\sisetup{group-separator={,},round-mode=places,round-precision=3}

--- a/paper/tex/sections/00_abstract.tex
+++ b/paper/tex/sections/00_abstract.tex
@@ -1,0 +1,3 @@
+\begin{abstract}
+% TODO: Write abstract.
+\end{abstract}

--- a/paper/tex/sections/01_introduction.tex
+++ b/paper/tex/sections/01_introduction.tex
@@ -1,0 +1,2 @@
+\section{Introduction}
+% TODO: Introduction content.

--- a/paper/tex/sections/02_related_work.tex
+++ b/paper/tex/sections/02_related_work.tex
@@ -1,0 +1,2 @@
+\section{Related Work}
+% TODO: Related work content.

--- a/paper/tex/sections/03_data.tex
+++ b/paper/tex/sections/03_data.tex
@@ -1,0 +1,2 @@
+\section{Data}
+% TODO: Data description.

--- a/paper/tex/sections/04_models.tex
+++ b/paper/tex/sections/04_models.tex
@@ -1,0 +1,2 @@
+\section{Models}
+% TODO: Modeling approach.

--- a/paper/tex/sections/05_pricing_calibration.tex
+++ b/paper/tex/sections/05_pricing_calibration.tex
@@ -1,0 +1,2 @@
+\section{Pricing Calibration}
+% TODO: Pricing calibration.

--- a/paper/tex/sections/06_microstructure_volatility.tex
+++ b/paper/tex/sections/06_microstructure_volatility.tex
@@ -1,0 +1,2 @@
+\section{Microstructure and Volatility}
+% TODO: Microstructure and volatility analysis.

--- a/paper/tex/sections/07_trading_strategy.tex
+++ b/paper/tex/sections/07_trading_strategy.tex
@@ -1,0 +1,2 @@
+\section{Trading Strategy}
+% TODO: Trading strategy details.

--- a/paper/tex/sections/08_backtesting.tex
+++ b/paper/tex/sections/08_backtesting.tex
@@ -1,0 +1,2 @@
+\section{Backtesting}
+% TODO: Backtesting procedures.

--- a/paper/tex/sections/09_results.tex
+++ b/paper/tex/sections/09_results.tex
@@ -1,0 +1,2 @@
+\section{Results}
+% TODO: Results discussion.

--- a/paper/tex/sections/10_robustness_risk.tex
+++ b/paper/tex/sections/10_robustness_risk.tex
@@ -1,0 +1,2 @@
+\section{Robustness and Risk}
+% TODO: Robustness checks and risk analysis.

--- a/paper/tex/sections/11_discussion.tex
+++ b/paper/tex/sections/11_discussion.tex
@@ -1,0 +1,2 @@
+\section{Discussion}
+% TODO: Discussion points.

--- a/paper/tex/sections/12_conclusion_future.tex
+++ b/paper/tex/sections/12_conclusion_future.tex
@@ -1,0 +1,2 @@
+\section{Conclusion and Future Work}
+% TODO: Conclusion and future work.

--- a/paper/tex/sections/A1_reproducibility.tex
+++ b/paper/tex/sections/A1_reproducibility.tex
@@ -1,0 +1,2 @@
+\section{Reproducibility}
+% TODO: Reproducibility details.

--- a/paper/tex/sections/A2_appendix.tex
+++ b/paper/tex/sections/A2_appendix.tex
@@ -1,0 +1,2 @@
+\section{Appendix}
+% TODO: Additional materials.

--- a/test.ipynb
+++ b/test.ipynb
@@ -1,0 +1,43 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "2839820f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "hello\n"
+     ]
+    }
+   ],
+   "source": [
+    "print('hello')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "tennis-ml",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- scaffold `paper/` directory with `main.tex`, section stubs, and bibliography
- add build configuration via `Makefile` and `latexmkrc`
- include `.gitignore` and README for paper workflow

## Testing
- `cd paper && make` *(fails: latexmk not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad7e223e5083238177956ecf0dcee2